### PR TITLE
fix 2019 holiday

### DIFF
--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -56,6 +56,10 @@ jholiday <- function(year, holiday.names = TRUE){
   }else {
     d <- .fixedDate("04-29", "The Emperor's Birthday")
   }
+  # National Holiday
+  if(year == 2019){
+    d <- .fixedDate("04-30", "National Holiday")
+  }
   # Marriage of Crown Prince Akihito
   if(year == 1959){
     d <- .fixedDate("04-10", "Marriage of Crown Prince Akihito")
@@ -67,6 +71,12 @@ jholiday <- function(year, holiday.names = TRUE){
     d <- .fixedDate("05-04", "Greenery Day")
   }else if(year >= 1988){
     d <- .fixedDate("05-04", "Citizens' Holiday")
+  }
+  # The Coronation Day 
+  # National Holiday
+  if(year == 2019){
+    d <- .fixedDate("05-01", "The Coronation Day")
+    d <- .fixedDate("05-02", "National Holiday")
   }
   # Children's Day
   d <- .fixedDate("05-05", "Children's Day")
@@ -114,6 +124,10 @@ jholiday <- function(year, holiday.names = TRUE){
   }else if(year > 1966){
     d <- .fixedDate("10-10", "Health and Sports Day")
   }
+  # Official Enthronement Ceremony of Emperor Akihito
+  if(year == 2019){
+    d <- .fixedDate("10-22", "Official Enthronement Ceremony of Emperor Naruhito")
+  }
   
   ## ====== November ==========
   # Culture Day
@@ -126,8 +140,8 @@ jholiday <- function(year, holiday.names = TRUE){
   }
 
   ## ====== December ==========
-  # The Emperor's Birthday
-  if(year >= 1989){
+  # The Heisei Emperor's Birthday
+  if(2018 >= year && year >= 1989){
     d <- .fixedDate("12-23", "The Emperor's Birthday")
   }
 

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -72,15 +72,15 @@ jholiday <- function(year, holiday.names = TRUE){
   }else if(year >= 1988){
     d <- .fixedDate("05-04", "Citizens' Holiday")
   }
-  # The Coronation Day 
+  # Coronation Day
   # National Holiday
   if(year == 2019){
-    d <- .fixedDate("05-01", "The Coronation Day")
+    d <- .fixedDate("05-01", "Coronation Day")
     d <- .fixedDate("05-02", "National Holiday")
   }
   # Children's Day
   d <- .fixedDate("05-05", "Children's Day")
-  
+
   ## ====== June ==========
   if(year == 1993){
     d <- .fixedDate("06-09", "Marriage of Crown Prince Naruhito")
@@ -100,7 +100,7 @@ jholiday <- function(year, holiday.names = TRUE){
   if(year >= 2016){
     d <- .fixedDate("08-11", "Mountain Day")
   }
-  
+
   ## ====== September ==========
   # Autumnal Equinox Day
   aed <- as.Date(paste(year, "09", .Shubun(year), sep = "-"))
@@ -128,7 +128,7 @@ jholiday <- function(year, holiday.names = TRUE){
   if(year == 2019){
     d <- .fixedDate("10-22", "Official Enthronement Ceremony of Emperor Naruhito")
   }
-  
+
   ## ====== November ==========
   # Culture Day
   d <- .fixedDate("11-03", "Culture Day")
@@ -189,7 +189,7 @@ is.jholiday <- function(dates){
   x <- d[w]
   return(x[ordinal])
 }
-  
+
 ## Calculation formulas in .Shunbun() and .Shubun() were referred to
 ## Shinkoyomi-benricho, Ephemeris Computation Workshop eds, Koseisha
 ## Koseikaku: Tokyo, 1991, ISBN: 9784769907008.


### PR DESCRIPTION
# Issue
https://github.com/inamori-albert/Nippon/issues/1
https://albert.backlog.jp/view/DI_PINK-1087

# 作業項目
- 新ジオセグメント作成時に利用する祝日日を取得する関数を確認したところ、2019年度の祝日で追加するべき日・削除するべき日ができていたため、修正する。

# フィードバックの期限
4/26

# 備考
片岡さんがなぜかpushできないので、稲盛が代わりにpush&PR作成